### PR TITLE
Make Python script names consistent with ROS naming conventions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,8 +153,8 @@ include_directories(
 ## Mark executable scripts (Python etc.) for installation
 ## in contrast to setup.py, you can choose the destination
 install(PROGRAMS
-  src/extract_all.py
-  src/extract_topic.py
+  src/extract_all
+  src/extract_topic
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ To install the data extraction tool, clone it to the `src` folder in your catkin
 # Usage
  * Extract all compatible topics in a bag file:
 
-`rosrun data_extract extract_all.py -b <path_to_bag_file> -o <path_to_output_dir>`
+`rosrun data_extract extract_all -b <path_to_bag_file> -o <path_to_output_dir>`
 
  * Extract a single topic:
 
-`rosrun data_extraction extract_topic.py -b <path_to_bag_file> -o <path_to_output_csv_file> -t <topic_name>`
+`rosrun data_extraction extract_topic -b <path_to_bag_file> -o <path_to_output_csv_file> -t <topic_name>`

--- a/package.xml
+++ b/package.xml
@@ -16,9 +16,9 @@
      * nav_msgs/Odometry
 
      1.) Extract all compatible topics in a bag file
-    rosrun data_extract extract_all.py -b path_to_bag_file -o path_to_output_dir
+    rosrun data_extract extract_all -b path_to_bag_file -o path_to_output_dir
      2.) Extract a single topic
-    rosrun data_extraction extract_topic.py -b path_to_bag_file -o path_to_output_csv_file -t topic_name
+    rosrun data_extraction extract_topic -b path_to_bag_file -o path_to_output_csv_file -t topic_name
 
       The extraction tool will only extract topics of the types listed above.
 

--- a/src/extract_all
+++ b/src/extract_all
@@ -10,7 +10,7 @@ import subprocess, yaml #required to check bag file contents
 
 def usage():
  	print " -----------------------------------  USAGE:  -------------------------------------------------"
- 	print " rosrun data_extraction extract_all.py -b rosbag_file_name -o output_dir_name"
+ 	print " rosrun data_extraction extract_all -b rosbag_file_name -o output_dir_name"
  	print ""
  	print " This code will extract all supported message types from the specified rosbag file. "
  	print ""
@@ -92,7 +92,7 @@ def main():
 			rospy.loginfo("----------------------- Starting TOPIC_EXTRACT.PY for %s --------------------------"%topicName)
 			fileName =  topicName.replace("/", "-")
 			fileName=fileName[1:]
-			commandLine = "rosrun ros_csv_extraction extract_topic.py -b " + rosbagFile + " -o " + outDir + "/" + fileName + ".csv" + " -t " + topicName
+			commandLine = "rosrun ros_csv_extraction extract_topic -b " + rosbagFile + " -o " + outDir + "/" + fileName + ".csv" + " -t " + topicName
 			os.system(commandLine)
 			rospy.loginfo("----------------------- Finished TOPIC_EXTRACT.PY for %s --------------------------"%topicName)
 		else:

--- a/src/extract_topic
+++ b/src/extract_topic
@@ -14,7 +14,7 @@ import getopt 	#used to parse arguments
 
 def usage():
  	print " -----------------------------------  USAGE:  -------------------------------------------------"
- 	print " rosrun data_extraction extract_topic.py -b bag_file_name -o output_file_name -t topic_name"
+ 	print " rosrun data_extraction extract_topic -b bag_file_name -o output_file_name -t topic_name"
  	print ""
  	print "  bag_file_name - path to ros .bag file containing ROS records"
  	print "  output_file_name - full path to csv file to save records to. If an image topic is specified"


### PR DESCRIPTION
ROS naming conventions specify to omit the extension of executable Python modules.